### PR TITLE
DMAPP-141: Fix info icon visibility in new single chats

### DIFF
--- a/src/navigation/screens/chats/SingleChatScreen.tsx
+++ b/src/navigation/screens/chats/SingleChatScreen.tsx
@@ -407,9 +407,12 @@ const SingleChatScreen = ({route}: any) => {
           </View>
         </View>
 
-        {feed && !feed.groupInformation ? (
-          <>
-            {/* {!(isIntentSendPage || isIntentReceivePage) && (
+        {/********************************************/
+        /**     Uncomment this conditional code     **/
+        /**     if video call feature is enabled    **/
+        /**    Note: enable for single user chat    **/
+        /********************************************/}
+        {/* {!(isIntentSendPage || isIntentReceivePage) && (
               <TouchableOpacity
                 onPress={startVideoCall}
                 style={styles.rightAligned}>
@@ -420,8 +423,8 @@ const SingleChatScreen = ({route}: any) => {
                 />
               </TouchableOpacity>
             )} */}
-          </>
-        ) : (
+
+        {feed && feed.groupInformation && (
           <TouchableOpacity
             style={styles.rightAligned}
             onPress={navigateToGroupInfo}>


### PR DESCRIPTION
### Solution
- Ensured info icon is not visible in new single chat headers.
- Corrected the condition for displaying the info icon in group chats only.

<img width="421" alt="Screenshot 2024-12-05 at 12 22 01 PM" src="https://github.com/user-attachments/assets/2dbb4bd1-8f3a-4a32-b9e9-9579ec90ba38">
