### PR TITLE
DMAPP-140: Fix encryption banner tap behavior

### DIFF
--- a/src/navigation/screens/chats/components/EncryptionInfo.tsx
+++ b/src/navigation/screens/chats/components/EncryptionInfo.tsx
@@ -9,7 +9,7 @@ interface EncryptionInfoProps {
 }
 
 const DOC_URL =
-  'https://docs.push.org/developers/concepts/push-chat-for-web3#encryption';
+  'https://push.org/docs/chat/concepts/encryption-version-in-push-chat';
 
 const EncryptionInfo = ({addrs, senderAddrs}: EncryptionInfoProps) => {
   const [isAccepted, setIsAccepted] = useState(false);
@@ -23,8 +23,6 @@ const EncryptionInfo = ({addrs, senderAddrs}: EncryptionInfoProps) => {
         addrs,
         senderAddrs,
       );
-      console.log(_isAccepted);
-
       setIsAccepted(_isAccepted);
     })();
   }, []);
@@ -70,7 +68,6 @@ const styles = StyleSheet.create({
   },
   icon: {
     paddingRight: 4,
-    // backgroundColor: 'red',
   },
   iconUnlock: {
     paddingRight: 2,


### PR DESCRIPTION
- Updated the encryption banner tap behavior to redirect to the correct URL.

<img width="420" alt="Screenshot 2024-12-05 at 12 34 40 PM" src="https://github.com/user-attachments/assets/cb018880-2d80-496c-9f6d-ca10160958a9">
